### PR TITLE
Feature/eels 3864 2.2.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.iml
+**/target/*
+*.log
+.idea
+**.DS_Store

--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-checkstyle</artifactId>
   <name>quartz-checkstyle</name>
-  <version>2.2.4-SNAPSHOT</version>
+  <version>2.2.3.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-checkstyle</artifactId>
   <name>quartz-checkstyle</name>
-  <version>2.2.3.1-SNAPSHOT</version>
+  <version>2.2.3.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-checkstyle</artifactId>
   <name>quartz-checkstyle</name>
-  <version>2.2.3</version>
+  <version>2.2.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/checkstyle/pom.xml
+++ b/checkstyle/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-checkstyle</artifactId>
   <name>quartz-checkstyle</name>
-  <version>2.2.3-SNAPSHOT</version>
+  <version>2.2.3</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/distribution/examples/pom.xml
+++ b/distribution/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/distribution/examples/pom.xml
+++ b/distribution/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/distribution/examples/pom.xml
+++ b/distribution/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/distribution/examples/pom.xml
+++ b/distribution/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>quartz-kit</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <artifactId>quartz-kit</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>quartz-kit</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <artifactId>quartz-kit</artifactId>

--- a/management-quartz-impl/pom.xml
+++ b/management-quartz-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <artifactId>management-quartz-impl</artifactId>

--- a/management-quartz-impl/pom.xml
+++ b/management-quartz-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>management-quartz-impl</artifactId>

--- a/management-quartz-impl/pom.xml
+++ b/management-quartz-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>management-quartz-impl</artifactId>

--- a/management-quartz-impl/pom.xml
+++ b/management-quartz-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <artifactId>management-quartz-impl</artifactId>

--- a/management-quartz/pom.xml
+++ b/management-quartz/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>management-quartz</artifactId>

--- a/management-quartz/pom.xml
+++ b/management-quartz/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
   
   <artifactId>management-quartz</artifactId>

--- a/management-quartz/pom.xml
+++ b/management-quartz/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
   
   <artifactId>management-quartz</artifactId>

--- a/management-quartz/pom.xml
+++ b/management-quartz/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
   
   <artifactId>management-quartz</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.quartz-scheduler</groupId>
   <artifactId>quartz-parent</artifactId>
-  <version>2.2.3</version>
+  <version>2.2.4-SNAPSHOT</version>
   <name>quartz-parent</name>
   <packaging>pom</packaging>
   

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.quartz-scheduler</groupId>
   <artifactId>quartz-parent</artifactId>
-  <version>2.2.3.1-SNAPSHOT</version>
+  <version>2.2.3.1</version>
   <name>quartz-parent</name>
   <packaging>pom</packaging>
   

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.quartz-scheduler</groupId>
   <artifactId>quartz-parent</artifactId>
-  <version>2.2.4-SNAPSHOT</version>
+  <version>2.2.3.1-SNAPSHOT</version>
   <name>quartz-parent</name>
   <packaging>pom</packaging>
   

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.quartz-scheduler</groupId>
   <artifactId>quartz-parent</artifactId>
-  <version>2.2.3-SNAPSHOT</version>
+  <version>2.2.3</version>
   <name>quartz-parent</name>
   <packaging>pom</packaging>
   

--- a/quartz-commonj/pom.xml
+++ b/quartz-commonj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-commonj/pom.xml
+++ b/quartz-commonj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-commonj/pom.xml
+++ b/quartz-commonj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-commonj/pom.xml
+++ b/quartz-commonj/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-core/pom.xml
+++ b/quartz-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-core/pom.xml
+++ b/quartz-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-core/pom.xml
+++ b/quartz-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-core/pom.xml
+++ b/quartz-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
+++ b/quartz-core/src/main/java/org/quartz/core/QuartzSchedulerThread.java
@@ -18,6 +18,7 @@
 
 package org.quartz.core;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -275,6 +276,13 @@ public class QuartzSchedulerThread extends Thread {
                         if (log.isDebugEnabled()) 
                             log.debug("batch acquisition of " + (triggers == null ? 0 : triggers.size()) + " triggers");
                     } catch (JobPersistenceException jpe) {
+                        if (jpe.getCause() instanceof SQLException) {
+                            SQLException sqe = (SQLException) jpe.getCause();
+                            log.error("Caught SQLException: Reason:" + sqe.getMessage());
+                            log.error("Caught SQLException: SQlState:" + sqe.getSQLState());
+                            log.error("Shutting down ... as I can't recover from SQLException");
+                            System.exit(sqe.getErrorCode());
+                        }
                         if(!lastAcquireFailed) {
                             qs.notifySchedulerListenersError(
                                 "An error occurred while scanning for the next triggers to fire.",

--- a/quartz-jboss/pom.xml
+++ b/quartz-jboss/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-jboss/pom.xml
+++ b/quartz-jboss/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-jboss/pom.xml
+++ b/quartz-jboss/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-jboss/pom.xml
+++ b/quartz-jboss/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-jobs/pom.xml
+++ b/quartz-jobs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler</groupId>

--- a/quartz-jobs/pom.xml
+++ b/quartz-jobs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler</groupId>
@@ -82,7 +82,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.9</version>
         <configuration>
-          <skip>${skipJavadoc}</skip>
+          <skip>true</skip>
           <quiet>true</quiet>
           <doctitle>Quartz Enterprise Job Scheduler ${project.version} - Utility jobs</doctitle>
           <windowtitle>Quartz Enterprise Job Scheduler ${project.version} - Utility jobs</windowtitle>

--- a/quartz-jobs/pom.xml
+++ b/quartz-jobs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler</groupId>

--- a/quartz-jobs/pom.xml
+++ b/quartz-jobs/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler</groupId>

--- a/quartz-oracle/pom.xml
+++ b/quartz-oracle/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-oracle/pom.xml
+++ b/quartz-oracle/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-oracle/pom.xml
+++ b/quartz-oracle/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-oracle/pom.xml
+++ b/quartz-oracle/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-plugins/pom.xml
+++ b/quartz-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-plugins/pom.xml
+++ b/quartz-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-plugins/pom.xml
+++ b/quartz-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-plugins/pom.xml
+++ b/quartz-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-stubs/pom.xml
+++ b/quartz-stubs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-stubs/pom.xml
+++ b/quartz-stubs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-stubs/pom.xml
+++ b/quartz-stubs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-stubs/pom.xml
+++ b/quartz-stubs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-weblogic/pom.xml
+++ b/quartz-weblogic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-weblogic/pom.xml
+++ b/quartz-weblogic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-weblogic/pom.xml
+++ b/quartz-weblogic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz-weblogic/pom.xml
+++ b/quartz-weblogic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <groupId>org.quartz-scheduler.internal</groupId>

--- a/quartz/pom.xml
+++ b/quartz/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>quartz</artifactId>

--- a/quartz/pom.xml
+++ b/quartz/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>quartz</artifactId>
@@ -129,6 +129,7 @@
             <dependencySourceInclude>org.quartz-scheduler.internal:*</dependencySourceInclude>
             <dependencySourceInclude>org.quartz-scheduler:quartz-jobs</dependencySourceInclude>
           </dependencySourceIncludes>
+          <failOnError>false</failOnError>
         </configuration>
         <executions>
           <execution>

--- a/quartz/pom.xml
+++ b/quartz/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <artifactId>quartz</artifactId>

--- a/quartz/pom.xml
+++ b/quartz/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <artifactId>quartz</artifactId>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-terracotta-system-tests</artifactId>
-  <version>2.2.3.1-SNAPSHOT</version>
+  <version>2.2.3.1</version>
   <name>quartz-terracotta-system-tests</name>
 
   <properties>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-terracotta-system-tests</artifactId>
-  <version>2.2.4-SNAPSHOT</version>
+  <version>2.2.3.1-SNAPSHOT</version>
   <name>quartz-terracotta-system-tests</name>
 
   <properties>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-terracotta-system-tests</artifactId>
-  <version>2.2.3</version>
+  <version>2.2.4-SNAPSHOT</version>
   <name>quartz-terracotta-system-tests</name>
 
   <properties>

--- a/system-tests/pom.xml
+++ b/system-tests/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>org.quartz-scheduler.internal</groupId>
   <artifactId>quartz-terracotta-system-tests</artifactId>
-  <version>2.2.3-SNAPSHOT</version>
+  <version>2.2.3</version>
   <name>quartz-terracotta-system-tests</name>
 
   <properties>

--- a/terracotta/bootstrap/pom.xml
+++ b/terracotta/bootstrap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler.internal</groupId>
     <artifactId>quartz-terracotta-root</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <name>quartz-terracotta-bootstrap</name>

--- a/terracotta/bootstrap/pom.xml
+++ b/terracotta/bootstrap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler.internal</groupId>
     <artifactId>quartz-terracotta-root</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <name>quartz-terracotta-bootstrap</name>

--- a/terracotta/bootstrap/pom.xml
+++ b/terracotta/bootstrap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler.internal</groupId>
     <artifactId>quartz-terracotta-root</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <name>quartz-terracotta-bootstrap</name>

--- a/terracotta/bootstrap/pom.xml
+++ b/terracotta/bootstrap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.quartz-scheduler.internal</groupId>
     <artifactId>quartz-terracotta-root</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <name>quartz-terracotta-bootstrap</name>

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.4-SNAPSHOT</version>
+    <version>2.2.3.1-SNAPSHOT</version>
   </parent>
 
   <name>quartz-terracotta-root</name>

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3.1-SNAPSHOT</version>
+    <version>2.2.3.1</version>
   </parent>
 
   <name>quartz-terracotta-root</name>

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3</version>
+    <version>2.2.4-SNAPSHOT</version>
   </parent>
 
   <name>quartz-terracotta-root</name>

--- a/terracotta/pom.xml
+++ b/terracotta/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.quartz-scheduler</groupId>
     <artifactId>quartz-parent</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.2.3</version>
   </parent>
 
   <name>quartz-terracotta-root</name>


### PR DESCRIPTION
@kazarian As discussed I changed the version scheme. We'll need to create a release out of the branch. 

A fix for Quartz to shutdown the scheduler when it encounters a
`SQLException`. Scheduler can't recover from such errors, even when
the database comes back up.

In order to compile under `java-8`, I had to take some shortcuts with
the pom. I had to disable some error checks and explicitly tell
the `quartz-jobs` module to skip javadocs checks. The project is full
of those errors. I'd rather Quartz fix those errors.

Rest of the changes are just incrementing the minor version.

How to compile:
- rename the `~/.m2/settings.xml` to `~/.m2/settings.xml.bak`
- ```mvn clean install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true```

we'll need to push this artifact to our nexus, so our projects can use them.

How I tested?
After I built this artifact, I moved the `~/.m2/settings.xml.bak` back to `~/.m2/settings.xml` and fired up `thirdparty-integrations`.

Waited until it came up.

Then I killed my database connection, and observed the following log sequence, including a graceful shutdown.

```
2018-01-30 08:27:02.840  INFO 16271 --- [pool-7-thread-1] c.p.t.batch.YodleeScheduledTasks         : SUCCESSFUL COBRAND LOGIN with Yodlee.  Updating YodleeCobrandSession
2018-01-30 08:27:03.872  INFO 16271 --- [           main] s.b.c.e.t.TomcatEmbeddedServletContainer : Tomcat started on port(s): 9005 (http)
2018-01-30 08:27:03.886  INFO 16271 --- [           main] c.p.thirdparty.ThirdPartyApplication     : Started ThirdPartyApplication in 21.867 seconds (JVM running for 23.396)
2018-01-30 08:27:21.928 ERROR 16271 --- [_ClusterManager] o.s.s.quartz.LocalDataSourceJobStore     : Couldn't rollback jdbc connection. This connection has been closed.

org.postgresql.util.PSQLException: This connection has been closed.
	at org.postgresql.jdbc.PgConnection.checkClosed(PgConnection.java:803) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.jdbc.PgConnection.rollback(PgConnection.java:810) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_151]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_151]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_151]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_151]
	at org.apache.tomcat.jdbc.pool.ProxyConnection.invoke(ProxyConnection.java:126) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:108) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor.invoke(AbstractCreateStatementInterceptor.java:79) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:108) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:81) ~[tomcat-jdbc-8.5.16.jar:na]
	at com.sun.proxy.$Proxy104.rollback(Unknown Source) ~[na:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_151]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_151]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_151]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_151]
	at org.quartz.impl.jdbcjobstore.AttributeRestoringConnectionInvocationHandler.invoke(AttributeRestoringConnectionInvocationHandler.java:73) ~[quartz-2.2.4-SNAPSHOT.jar:na]
	at com.sun.proxy.$Proxy160.rollback(Unknown Source) ~[na:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.rollbackConnection(JobStoreSupport.java:3666) [quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.doCheckin(JobStoreSupport.java:3293) [quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$ClusterManager.manage(JobStoreSupport.java:3874) [quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$ClusterManager.run(JobStoreSupport.java:3911) [quartz-2.2.4-SNAPSHOT.jar:na]

2018-01-30 08:27:21.929  WARN 16271 --- [_ClusterManager] buteRestoringConnectionInvocationHandler : Failed restore connection's original auto commit setting.

org.postgresql.util.PSQLException: This connection has been closed.
	at org.postgresql.jdbc.PgConnection.checkClosed(PgConnection.java:803) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.jdbc.PgConnection.setAutoCommit(PgConnection.java:750) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_151]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_151]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_151]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_151]
	at org.apache.tomcat.jdbc.pool.ProxyConnection.invoke(ProxyConnection.java:126) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:108) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor.invoke(AbstractCreateStatementInterceptor.java:79) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:108) ~[tomcat-jdbc-8.5.16.jar:na]
	at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:81) ~[tomcat-jdbc-8.5.16.jar:na]
	at com.sun.proxy.$Proxy104.setAutoCommit(Unknown Source) ~[na:na]
	at org.quartz.impl.jdbcjobstore.AttributeRestoringConnectionInvocationHandler.restoreOriginalAtributes(AttributeRestoringConnectionInvocationHandler.java:141) ~[quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.cleanupConnection(JobStoreSupport.java:3616) [quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.doCheckin(JobStoreSupport.java:3302) [quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$ClusterManager.manage(JobStoreSupport.java:3874) [quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$ClusterManager.run(JobStoreSupport.java:3911) [quartz-2.2.4-SNAPSHOT.jar:na]

2018-01-30 08:27:21.929 ERROR 16271 --- [_ClusterManager] o.s.s.quartz.LocalDataSourceJobStore     : ClusterManager: Error managing cluster: Failure identifying failed instances when checking-in: FATAL: terminating connection due to administrator command

org.quartz.JobPersistenceException: Failure identifying failed instances when checking-in: FATAL: terminating connection due to administrator command
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.findFailedInstances(JobStoreSupport.java:3360) ~[quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.clusterCheckIn(JobStoreSupport.java:3409) ~[quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.doCheckin(JobStoreSupport.java:3269) ~[quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$ClusterManager.manage(JobStoreSupport.java:3874) [quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$ClusterManager.run(JobStoreSupport.java:3911) [quartz-2.2.4-SNAPSHOT.jar:na]
Caused by: org.postgresql.util.PSQLException: FATAL: terminating connection due to administrator command
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2455) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2155) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:288) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:430) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:356) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:168) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:116) ~[postgresql-9.4.1212.jre7.jar:9.4.1212.jre7]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_151]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_151]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_151]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_151]
	at org.apache.tomcat.jdbc.pool.StatementFacade$StatementProxy.invoke(StatementFacade.java:114) ~[tomcat-jdbc-8.5.16.jar:na]
	at com.sun.proxy.$Proxy161.executeQuery(Unknown Source) ~[na:na]
	at org.quartz.impl.jdbcjobstore.StdJDBCDelegate.selectSchedulerStateRecords(StdJDBCDelegate.java:2994) ~[quartz-2.2.4-SNAPSHOT.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.findFailedInstances(JobStoreSupport.java:3323) ~[quartz-2.2.4-SNAPSHOT.jar:na]
	... 4 common frames omitted

**2018-01-30 08:27:27.534 ERROR 16271 --- [SchedulerThread] org.quartz.core.QuartzSchedulerThread    : Caught SQLException: Reason:Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.**
**2018-01-30 08:27:27.534 ERROR 16271 --- [SchedulerThread] org.quartz.core.QuartzSchedulerThread    : Caught SQLException: SQlState:08001
2018-01-30 08:27:27.534 ERROR 16271 --- [SchedulerThread] org.quartz.core.QuartzSchedulerThread    : Shutting down ... as I can't recover from SQLException**
2018-01-30 08:27:27.535  INFO 16271 --- [      Thread-53] ationConfigEmbeddedWebApplicationContext : Closing org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext@3ad83a66: startup date [Tue Jan 30 08:26:43 MST 2018]; root of context hierarchy
2018-01-30 08:27:27.538  INFO 16271 --- [      Thread-53] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase 2147483647
2018-01-30 08:27:27.538  INFO 16271 --- [      Thread-53] org.quartz.core.QuartzScheduler          : Scheduler thirdparty-quartz_$_ip-172-16-30-91.ec2.internal1517326017003 paused.
2018-01-30 08:27:27.542  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Waiting for workers to finish.
2018-01-30 08:27:28.171  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Successfully waited for workers to finish.
2018-01-30 08:27:28.172  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Waiting for workers to finish.
2018-01-30 08:27:28.174  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Successfully waited for workers to finish.
2018-01-30 08:27:28.175  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Waiting for workers to finish.
2018-01-30 08:27:29.178  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Successfully waited for workers to finish.
2018-01-30 08:27:29.179  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Waiting for workers to finish.
2018-01-30 08:27:30.184  INFO 16271 --- [      Thread-53] o.s.a.r.l.SimpleMessageListenerContainer : Successfully waited for workers to finish.
2018-01-30 08:27:30.184  INFO 16271 --- [      Thread-53] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase 0
2018-01-30 08:27:30.184  INFO 16271 --- [      Thread-53] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase -2147482648
2018-01-30 08:27:30.185  INFO 16271 --- [      Thread-53] o.s.j.e.a.AnnotationMBeanExporter        : Unregistering JMX-exposed beans on shutdown
2018-01-30 08:27:30.185  INFO 16271 --- [      Thread-53] o.s.j.e.a.AnnotationMBeanExporter        : Unregistering JMX-exposed beans
2018-01-30 08:27:30.188  INFO 16271 --- [      Thread-53] o.s.s.quartz.SchedulerFactoryBean        : Shutting down Quartz Scheduler
2018-01-30 08:27:30.188  INFO 16271 --- [      Thread-53] org.quartz.core.QuartzScheduler          : Scheduler thirdparty-quartz_$_ip-172-16-30-91.ec2.internal1517326017003 shutting down.
2018-01-30 08:27:30.188  INFO 16271 --- [      Thread-53] org.quartz.core.QuartzScheduler          : Scheduler thirdparty-quartz_$_ip-172-16-30-91.ec2.internal1517326017003 paused.
2018-01-30 08:27:30.189  INFO 16271 --- [      Thread-53] org.quartz.core.QuartzScheduler          : Scheduler thirdparty-quartz_$_ip-172-16-30-91.ec2.internal1517326017003 shutdown complete.
2018-01-30 08:27:30.224  INFO 16271 --- [      Thread-53] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2018-01-30 08:27:30.225  INFO 16271 --- [      Thread-53] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'

Process finished with exit code 0
```
